### PR TITLE
Refresh token

### DIFF
--- a/.versions.json
+++ b/.versions.json
@@ -1,4 +1,4 @@
 {
-  "precog-quasar": "198.0.3",
-  "precog-async-blobstore": "4.0.5"
+  "precog-quasar": "198.0.3-9bccff5",
+  "precog-async-blobstore": "4.0.5-53942fb"
 }

--- a/core/src/main/scala/quasar/physical/blobstore/BlobstoreDatasource.scala
+++ b/core/src/main/scala/quasar/physical/blobstore/BlobstoreDatasource.scala
@@ -37,51 +37,57 @@ import fs2.Stream
 class BlobstoreDatasource[F[_]: Monad: MonadResourceErr, P](
     val kind: DatasourceType,
     format: DataFormat,
-    statusService: StatusService[F],
-    listService: ListService[F],
-    propsService: PropsService[F, P],
-    getService: GetService[F])
+    statusService: F[StatusService[F]],
+    listService: F[ListService[F]],
+    propsService: F[PropsService[F, P]],
+    getService: F[GetService[F]])
     extends LightweightDatasource[Resource[F, ?], Stream[F, ?], QueryResult[F]] {
 
   private def raisePathNotFound(path: ResourcePath) =
     MonadResourceErr[F].raiseError(ResourceError.pathNotFound(path))
 
-  val loaders = NonEmptyList.of(Loader.Batch(BatchLoader.Full { (iRead: InterpretedRead[ResourcePath]) =>
+  val loaders = NonEmptyList.of(Loader.Batch(BatchLoader.Full(fullLoad)))
+
+  def fullLoad(iRead: InterpretedRead[ResourcePath]): Resource[F, QueryResult[F]] =
     Resource.liftF(for {
-      optBytes <- (converters.resourcePathToBlobPathK[F] andThen getService).apply(iRead.path)
+      svc <- getService
+      optBytes <- (converters.resourcePathToBlobPathK[F] andThen svc).apply(iRead.path)
       bytes <- optBytes.map(_.pure[F]).getOrElse(raisePathNotFound(iRead.path))
       qr = QueryResult.typed[F](format, bytes, iRead.stages)
     } yield qr)
-  }))
 
   override def pathIsResource(path: ResourcePath): Resource[F, Boolean] =
-    converters.resourcePathToBlobPathK
-      .andThen(propsService)
-      .mapK(Resource.liftK)
-      .map(_.isDefined)
-      .apply(path)
+    Resource.liftF(propsService) flatMap { svc =>
+      converters.resourcePathToBlobPathK
+        .andThen(svc)
+        .mapK(Resource.liftK)
+        .map(_.isDefined)
+        .apply(path)
+    }
 
   override def prefixedChildPaths(prefixPath: ResourcePath)
       : Resource[F, Option[Stream[F, (ResourceName, ResourcePathType.Physical)]]] =
-    converters.resourcePathToPrefixPathK
-      .andThen(listService)
-      .mapK(Resource.liftK)
-      .map(_.map(_.map(converters.toResourceNameType)))
-      .apply(prefixPath)
+    Resource.liftF(listService) flatMap { svc =>
+      converters.resourcePathToPrefixPathK
+        .andThen(svc)
+        .mapK(Resource.liftK)
+        .map(_.map(_.map(converters.toResourceNameType)))
+        .apply(prefixPath)
+    }
 
   def asDsType: LightweightDatasourceModule.DS[F] = this
 
-  def status: StatusService[F] = statusService
+  def status: StatusService[F] = statusService.flatten
 }
 
 object BlobstoreDatasource {
   def apply[F[_]: Monad: MonadResourceErr, P](
       kind: DatasourceType,
       format: DataFormat,
-      statusService: StatusService[F],
-      listService: ListService[F],
-      propsService: PropsService[F, P],
-      getService: GetService[F])
+      statusService: F[StatusService[F]],
+      listService: F[ListService[F]],
+      propsService: F[PropsService[F, P]],
+      getService: F[GetService[F]])
       : BlobstoreDatasource[F, P] =
     new BlobstoreDatasource(kind, format, statusService, listService, propsService, getService)
 }


### PR DESCRIPTION
[ch12536]

Support refresh for Azure datasource and use new version of async-blobstore (that uses upgraded Azure SDK which also includes token expiration fixes).

Marked as breaking because of Netty bump.
🛑  until other Netty dependent plugins/components are upgraded too.